### PR TITLE
Safely convert from uint64_t to size_t.

### DIFF
--- a/rmw_dps_cpp/include/rmw_dps_cpp/CborStream.hpp
+++ b/rmw_dps_cpp/include/rmw_dps_cpp/CborStream.hpp
@@ -488,7 +488,7 @@ public:
     if (info > std::numeric_limits<std::size_t>::max()) {
       throw std::runtime_error("array size too large");
     }
-    *size = info;
+    *size = (size_t)info;
     return *this;
   }
 

--- a/rmw_dps_cpp/include/rmw_dps_cpp/CborStream.hpp
+++ b/rmw_dps_cpp/include/rmw_dps_cpp/CborStream.hpp
@@ -18,6 +18,7 @@
 #include <dps/private/cbor.h>
 
 #include <algorithm>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/rmw_dps_cpp/include/rmw_dps_cpp/CborStream.hpp
+++ b/rmw_dps_cpp/include/rmw_dps_cpp/CborStream.hpp
@@ -480,10 +480,15 @@ public:
   inline RxStream & deserializeSequenceSize(size_t * size)
   {
     uint8_t maj;
-    DPS_Status ret = CBOR_Peek(&buffer_, &maj, size);
+    uint64_t info;
+    DPS_Status ret = CBOR_Peek(&buffer_, &maj, &info);
     if (ret != DPS_OK || (maj != CBOR_ARRAY && maj != CBOR_BYTES)) {
       throw std::runtime_error("failed to deserialize array size");
     }
+    if (info > std::numeric_limits<std::size_t>::max()) {
+      throw std::runtime_error("array size too large");
+    }
+    *size = info;
     return *this;
   }
 


### PR DESCRIPTION
This fixes #8.

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>