### PR TITLE
Fix linting errors (CI passes)

### DIFF
--- a/dps_for_iot_cmake_module/CMakeLists.txt
+++ b/dps_for_iot_cmake_module/CMakeLists.txt
@@ -24,6 +24,8 @@ find_package(ament_cmake REQUIRED)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # Do not lint CMake files (the configuration used by ament does not allow for mixed case as in ExternalProject_Add).
+  set(ament_cmake_lint_cmake_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/rmw_dps_cpp/include/rmw_dps_cpp/Listener.hpp
+++ b/rmw_dps_cpp/include/rmw_dps_cpp/Listener.hpp
@@ -49,7 +49,7 @@ public:
   {
     RCUTILS_LOG_DEBUG_NAMED(
       "rmw_dps_cpp",
-      "%s(sub=%p,pub=%p,payload=%p,len=%zu)", __FUNCTION__, (void*)sub, (void*)pub, payload, len);
+      "%s(sub=%p,pub=%p,payload=%p,len=%zu)", __FUNCTION__, (void *)sub, (void *)pub, payload, len);
     RCUTILS_LOG_DEBUG_NAMED(
       "rmw_dps_cpp",
       "pub={uuid=%s,sequenceNum=%d}", DPS_UUIDToString(DPS_PublicationGetUUID(pub)),
@@ -77,7 +77,7 @@ public:
   {
     RCUTILS_LOG_DEBUG_NAMED(
       "rmw_dps_cpp",
-      "%s(pub=%p,payload=%p,len=%zu)", __FUNCTION__, (void*)pub, payload, len);
+      "%s(pub=%p,payload=%p,len=%zu)", __FUNCTION__, (void *)pub, payload, len);
     RCUTILS_LOG_DEBUG_NAMED(
       "rmw_dps_cpp",
       "pub={uuid=%s,sequenceNum=%u}", DPS_UUIDToString(DPS_PublicationGetUUID(pub)),

--- a/rmw_dps_cpp/src/rmw_client.cpp
+++ b/rmw_dps_cpp/src/rmw_client.cpp
@@ -39,7 +39,7 @@ rmw_create_client(
     "rmw_dps_cpp",
     "%s(node=%p,type_supports=%p,service_name=%s,"
     "qos_policies={history=%d,depth=%zu,reliability=%d,durability=%d})",
-    __FUNCTION__, (void*)node, (void*)type_supports, service_name, qos_policies->history,
+    __FUNCTION__, (void *)node, (void *)type_supports, service_name, qos_policies->history,
     qos_policies->depth, qos_policies->reliability, qos_policies->durability);
 
   if (!node) {
@@ -190,7 +190,7 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(node=%p,client=%p)", __FUNCTION__, (void*)node, (void*)client);
+    "%s(node=%p,client=%p)", __FUNCTION__, (void *)node, (void *)client);
 
   if (!node) {
     RMW_SET_ERROR_MSG("node handle is null");

--- a/rmw_dps_cpp/src/rmw_compare_gids_equal.cpp
+++ b/rmw_dps_cpp/src/rmw_compare_gids_equal.cpp
@@ -28,7 +28,7 @@ rmw_compare_gids_equal(const rmw_gid_t * gid1, const rmw_gid_t * gid2, bool * re
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(gid1=%p,gid2=%p,result=%p)", __FUNCTION__, (void*)gid1, (void*)gid2, (void*)result);
+    "%s(gid1=%p,gid2=%p,result=%p)", __FUNCTION__, (void *)gid1, (void *)gid2, (void *)result);
 
   if (!gid1) {
     RMW_SET_ERROR_MSG("gid1 is null");

--- a/rmw_dps_cpp/src/rmw_count.cpp
+++ b/rmw_dps_cpp/src/rmw_count.cpp
@@ -26,7 +26,7 @@ rmw_count_publishers(
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(node=%p,topic_name=%s,count=%p)", __FUNCTION__, (void*)node, topic_name, (void*)count);
+    "%s(node=%p,topic_name=%s,count=%p)", __FUNCTION__, (void *)node, topic_name, (void *)count);
 
   // TODO(malsbat): implement
   *count = 0;
@@ -41,7 +41,7 @@ rmw_count_subscribers(
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(node=%p,topic_name=%s,count=%p)", __FUNCTION__, (void*)node, topic_name, (void*)count);
+    "%s(node=%p,topic_name=%s,count=%p)", __FUNCTION__, (void *)node, topic_name, (void *)count);
 
   // TODO(malsbat): implement
   *count = 0;

--- a/rmw_dps_cpp/src/rmw_get_gid_for_publisher.cpp
+++ b/rmw_dps_cpp/src/rmw_get_gid_for_publisher.cpp
@@ -27,7 +27,7 @@ rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t * gid)
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(publisher=%p,gid=%p)", __FUNCTION__, (void*)publisher, (void*)gid);
+    "%s(publisher=%p,gid=%p)", __FUNCTION__, (void *)publisher, (void *)gid);
 
   if (!publisher) {
     RMW_SET_ERROR_MSG("publisher is null");

--- a/rmw_dps_cpp/src/rmw_node.cpp
+++ b/rmw_dps_cpp/src/rmw_node.cpp
@@ -192,7 +192,7 @@ rmw_destroy_node(rmw_node_t * node)
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(node=%p)", __FUNCTION__, (void*)node);
+    "%s(node=%p)", __FUNCTION__, (void *)node);
 
   rmw_ret_t result_ret = RMW_RET_OK;
   if (!node) {
@@ -247,7 +247,7 @@ rmw_node_get_graph_guard_condition(const rmw_node_t * node)
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(node=%p)", __FUNCTION__, (void*)node);
+    "%s(node=%p)", __FUNCTION__, (void *)node);
 
   auto impl = static_cast<CustomNodeInfo *>(node->data);
   if (!impl) {

--- a/rmw_dps_cpp/src/rmw_node_info_and_types.cpp
+++ b/rmw_dps_cpp/src/rmw_node_info_and_types.cpp
@@ -39,8 +39,8 @@ rmw_get_subscriber_names_and_types_by_node(
     "rmw_dps_cpp",
     "%s(node=%p,allocator=%p,node_name=%s,node_namespace=%s,no_demangle=%d,"
     "topic_names_and_types=%p)",
-    __FUNCTION__, (void*)node, (void*)allocator, node_name, node_namespace, no_demangle,
-    (void*)topic_names_and_types);
+    __FUNCTION__, (void *)node, (void *)allocator, node_name, node_namespace, no_demangle,
+    reinterpret_cast<void *>(topic_names_and_types));
 
   return RMW_RET_OK;
 }
@@ -59,8 +59,8 @@ rmw_get_publisher_names_and_types_by_node(
     "rmw_dps_cpp",
     "%s(node=%p,allocator=%p,node_name=%s,node_namespace=%s,no_demangle=%d,"
     "topic_names_and_types=%p)",
-    __FUNCTION__, (void*)node, (void*)allocator, node_name, node_namespace, no_demangle,
-    (void*)topic_names_and_types);
+    __FUNCTION__, (void *)node, (void *)allocator, node_name, node_namespace, no_demangle,
+    reinterpret_cast<void *>(topic_names_and_types));
 
   return RMW_RET_OK;
 }
@@ -77,8 +77,8 @@ rmw_get_service_names_and_types_by_node(
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
     "%s(node=%p,allocator=%p,node_name=%s,node_namespace=%s,service_names_and_types=%p)",
-    __FUNCTION__, (void*)node, (void*)allocator, node_name, node_namespace,
-    (void*)service_names_and_types);
+    __FUNCTION__, (void *)node, (void *)allocator, node_name, node_namespace,
+    (void *)service_names_and_types);
 
   return RMW_RET_OK;
 }

--- a/rmw_dps_cpp/src/rmw_publish.cpp
+++ b/rmw_dps_cpp/src/rmw_publish.cpp
@@ -36,7 +36,7 @@ rmw_publish(
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
     "%s(publisher=%p,ros_message=%p,allocation=%p)",
-    __FUNCTION__, (void*)publisher, (void*)ros_message, (void*)allocation);
+    __FUNCTION__, (void *)publisher, (void *)ros_message, (void *)allocation);
 
   rmw_ret_t returnedValue = RMW_RET_ERROR;
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(publisher, "publisher pointer is null", return RMW_RET_ERROR);

--- a/rmw_dps_cpp/src/rmw_publisher.cpp
+++ b/rmw_dps_cpp/src/rmw_publisher.cpp
@@ -103,9 +103,10 @@ rmw_create_publisher(
     "rmw_dps_cpp",
     "%s(node=%p,type_supports=%p,topic_name=%s,"
     "qos_policies={history=%s,depth=%zu,reliability=%s,durability=%s})",
-    __FUNCTION__, (void*)node, (void*)type_supports, topic_name,
+    __FUNCTION__, (void *)node, (void *)type_supports, topic_name,
     qos_history_string(qos_policies->history), qos_policies->depth,
-    qos_reliability_string(qos_policies->reliability), qos_durability_string(qos_policies->durability));
+    qos_reliability_string(qos_policies->reliability),
+    qos_durability_string(qos_policies->durability));
 
   if (!node) {
     RMW_SET_ERROR_MSG("node handle is null");
@@ -230,8 +231,8 @@ rmw_publisher_count_matched_subscriptions(
   // TODO(malsbat): implement
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(publisher=%p,subscription_count=%p)", __FUNCTION__, (void*)publisher,
-    (void*)subscription_count);
+    "%s(publisher=%p,subscription_count=%p)", __FUNCTION__, (void *)publisher,
+    (void *)subscription_count);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(publisher, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription_count, RMW_RET_INVALID_ARGUMENT);
@@ -244,7 +245,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(node=%p,publisher=%p)", __FUNCTION__, (void*)node, (void*)publisher);
+    "%s(node=%p,publisher=%p)", __FUNCTION__, (void *)node, (void *)publisher);
 
   if (!node) {
     RMW_SET_ERROR_MSG("node handle is null");

--- a/rmw_dps_cpp/src/rmw_request.cpp
+++ b/rmw_dps_cpp/src/rmw_request.cpp
@@ -36,8 +36,8 @@ rmw_send_request(
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(client=%p,ros_request=%p,sequence_id=%p)", __FUNCTION__, (void*)client, ros_request,
-    (void*)sequence_id);
+    "%s(client=%p,ros_request=%p,sequence_id=%p)", __FUNCTION__, (void *)client, ros_request,
+    (void *)sequence_id);
 
   assert(client);
   assert(ros_request);
@@ -79,8 +79,8 @@ rmw_take_request(
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(service=%p,request_header=%p,ros_request=%p,taken=%p)", __FUNCTION__, (void*)service,
-    (void*)request_header, ros_request, (void*)taken);
+    "%s(service=%p,request_header=%p,ros_request=%p,taken=%p)", __FUNCTION__, (void *)service,
+    (void *)request_header, ros_request, (void *)taken);
 
   assert(service);
   assert(request_header);

--- a/rmw_dps_cpp/src/rmw_response.cpp
+++ b/rmw_dps_cpp/src/rmw_response.cpp
@@ -37,8 +37,8 @@ rmw_take_response(
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(client=%p,request_header=%p,ros_request=%p,taken=%p)", __FUNCTION__, (void*)client,
-    (void*)request_header, ros_response, (void*)taken);
+    "%s(client=%p,request_header=%p,ros_request=%p,taken=%p)", __FUNCTION__, (void *)client,
+    (void *)request_header, ros_response, (void *)taken);
 
   assert(client);
   assert(request_header);
@@ -84,8 +84,8 @@ rmw_send_response(
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(service=%p,request_header=%p,ros_response=%p)", __FUNCTION__, (void*)service,
-    (void*)request_header, ros_response);
+    "%s(service=%p,request_header=%p,ros_response=%p)", __FUNCTION__, (void *)service,
+    (void *)request_header, ros_response);
 
   assert(service);
   assert(request_header);

--- a/rmw_dps_cpp/src/rmw_serialize.cpp
+++ b/rmw_dps_cpp/src/rmw_serialize.cpp
@@ -30,7 +30,7 @@ rmw_serialize(
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
     "%s(ros_message=%p,type_support=%p,serialized_message=%p)", __FUNCTION__, ros_message,
-    (void*)type_support, (void*)serialized_message);
+    (void *)type_support, (void *)serialized_message);
 
   const rosidl_message_type_support_t * ts = get_message_typesupport_handle(
     type_support, rosidl_typesupport_introspection_c__identifier);
@@ -69,8 +69,8 @@ rmw_deserialize(
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(serialized_message=%p,type_support=%p,ros_message=%p)", __FUNCTION__, (void*)serialized_message,
-    (void*)type_support, ros_message);
+    "%s(serialized_message=%p,type_support=%p,ros_message=%p)", __FUNCTION__,
+    (void *)serialized_message, (void *)type_support, ros_message);
 
   const rosidl_message_type_support_t * ts = get_message_typesupport_handle(
     type_support, rosidl_typesupport_introspection_c__identifier);

--- a/rmw_dps_cpp/src/rmw_service.cpp
+++ b/rmw_dps_cpp/src/rmw_service.cpp
@@ -40,7 +40,7 @@ rmw_create_service(
     "rmw_dps_cpp",
     "%s(node=%p,type_supports=%p,service_name=%s,"
     "qos_policies={history=%d,depth=%zu,reliability=%d,durability=%d})",
-    __FUNCTION__, (void*)node, (void*)type_supports, service_name, qos_policies->history,
+    __FUNCTION__, (void *)node, (void *)type_supports, service_name, qos_policies->history,
     qos_policies->depth, qos_policies->reliability, qos_policies->durability);
 
   if (!node) {
@@ -179,7 +179,7 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(node=%p,service=%p)", __FUNCTION__, (void*)node, (void*)service);
+    "%s(node=%p,service=%p)", __FUNCTION__, (void *)node, (void *)service);
 
   if (!node) {
     RMW_SET_ERROR_MSG("node handle is null");

--- a/rmw_dps_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_dps_cpp/src/rmw_service_server_is_available.cpp
@@ -30,8 +30,8 @@ rmw_service_server_is_available(
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(node=%p,client=%p,is_available=%p)", __FUNCTION__, (void*)node, (void*)client,
-    (void*)is_available);
+    "%s(node=%p,client=%p,is_available=%p)", __FUNCTION__, (void *)node, (void *)client,
+    (void *)is_available);
 
   if (!node) {
     RMW_SET_ERROR_MSG("node handle is null");

--- a/rmw_dps_cpp/src/rmw_subscription.cpp
+++ b/rmw_dps_cpp/src/rmw_subscription.cpp
@@ -61,9 +61,13 @@ rmw_create_subscription(
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
     "%s(node=%p,type_supports=%p,topic_name=%s,"
-    "qos_policies={history=%d,depth=%zu,reliability=%d,durability=%d},ignore_local_publications=%d)",
-    __FUNCTION__, (void*)node, (void*)type_supports, topic_name, qos_policies->history,
-    qos_policies->depth, qos_policies->reliability, qos_policies->durability, ignore_local_publications);
+    "qos_policies={history=%d,depth=%zu,reliability=%d,durability=%d},"
+    "ignore_local_publications=%d)",
+    __FUNCTION__,
+    reinterpret_cast<const void *>(node), reinterpret_cast<const void *>(type_supports),
+    topic_name, qos_policies->history,
+    qos_policies->depth, qos_policies->reliability, qos_policies->durability,
+    ignore_local_publications);
 
   if (!node) {
     RMW_SET_ERROR_MSG("node handle is null");
@@ -183,7 +187,8 @@ rmw_subscription_count_matched_publishers(
   // TODO(malsbat): implement
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(subscription=%p,publisher_count=%p)", __FUNCTION__, (void*)subscription, (void*)publisher_count);
+    "%s(subscription=%p,publisher_count=%p)", __FUNCTION__,
+    (void *)subscription, (void *)publisher_count);
 
   return RMW_RET_OK;
 }
@@ -193,7 +198,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(node=%p,subscription=%p)", __FUNCTION__, (void*)node, (void*)subscription);
+    "%s(node=%p,subscription=%p)", __FUNCTION__, (void *)node, (void *)subscription);
 
   if (!node) {
     RMW_SET_ERROR_MSG("node handle is null");

--- a/rmw_dps_cpp/src/rmw_take.cpp
+++ b/rmw_dps_cpp/src/rmw_take.cpp
@@ -85,8 +85,8 @@ rmw_take(
 
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(subscription=%p,ros_message=%p,taken=%p,allocation=%p)", __FUNCTION__, (void*)subscription,
-    ros_message, (void*)taken, (void*)allocation);
+    "%s(subscription=%p,ros_message=%p,taken=%p,allocation=%p)", __FUNCTION__, (void *)subscription,
+    ros_message, (void *)taken, (void *)allocation);
 
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     subscription, "subscription pointer is null", return RMW_RET_ERROR);
@@ -111,7 +111,7 @@ rmw_take_with_info(
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
     "%s(subscription=%p,ros_message=%p,taken=%p,message_info=%p,allocation=%p)", __FUNCTION__,
-    (void*)subscription, ros_message, (void*)taken, (void*)message_info, (void*)allocation);
+    (void *)subscription, ros_message, (void *)taken, (void *)message_info, (void *)allocation);
 
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     subscription, "subscription pointer is null", return RMW_RET_ERROR);
@@ -177,7 +177,7 @@ rmw_take_serialized_message(
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
     "%s(subscription=%p,serialized_message=%p,taken=%p,allocation=%p)", __FUNCTION__,
-    (void*)subscription, (void*)serialized_message, (void*)taken, (void*)allocation);
+    (void *)subscription, (void *)serialized_message, (void *)taken, (void *)allocation);
 
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     subscription, "subscription pointer is null", return RMW_RET_ERROR);
@@ -201,9 +201,11 @@ rmw_take_serialized_message_with_info(
 
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(subscription=%p,serialized_message=%p,taken=%p,message_info=%p,allocation=%p)", __FUNCTION__,
-    (void*)subscription, (void*)serialized_message, (void*)taken, (void*)message_info,
-    (void*)allocation);
+    "%s(subscription=%p,serialized_message=%p,taken=%p,message_info=%p,allocation=%p)",
+    __FUNCTION__,
+    reinterpret_cast<const void *>(subscription), reinterpret_cast<void *>(serialized_message),
+    reinterpret_cast<void *>(taken), reinterpret_cast<void *>(message_info),
+    reinterpret_cast<void *>(allocation));
 
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     subscription, "subscription pointer is null", return RMW_RET_ERROR);

--- a/rmw_dps_cpp/src/rmw_wait.cpp
+++ b/rmw_dps_cpp/src/rmw_wait.cpp
@@ -92,8 +92,9 @@ rmw_wait(
     "rmw_dps_cpp",
     "%s(subscriptions=%p,guard_conditions=%p,services=%p,clients=%p,events=%p,wait_set=%p,"
     "wait_timeout=%p)",
-    __FUNCTION__, (void*)subscriptions, (void*)guard_conditions, (void*)services, (void*)clients,
-    (void*)events, (void*)wait_set, (void*)wait_timeout);
+    __FUNCTION__, (void *)subscriptions, (void *)guard_conditions, (void *)services,
+    reinterpret_cast<void *>(clients), reinterpret_cast<void *>(events),
+    reinterpret_cast<void *>(wait_set), reinterpret_cast<const void *>(wait_timeout));
 
   if (!wait_set) {
     RMW_SET_ERROR_MSG("wait set handle is null");

--- a/rmw_dps_cpp/src/rmw_wait_set.cpp
+++ b/rmw_dps_cpp/src/rmw_wait_set.cpp
@@ -29,7 +29,7 @@ rmw_create_wait_set(rmw_context_t * context, size_t max_conditions)
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(context=%p,max_conditions=%zu)", __FUNCTION__, (void*)context, max_conditions);
+    "%s(context=%p,max_conditions=%zu)", __FUNCTION__, (void *)context, max_conditions);
 
   (void)max_conditions;
   rmw_wait_set_t * wait_set = rmw_wait_set_allocate();
@@ -69,7 +69,7 @@ rmw_destroy_wait_set(rmw_wait_set_t * wait_set)
 {
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_dps_cpp",
-    "%s(wait_set=%p)", __FUNCTION__, (void*)wait_set);
+    "%s(wait_set=%p)", __FUNCTION__, (void *)wait_set);
 
   if (!wait_set) {
     RMW_SET_ERROR_MSG("wait set handle is null");


### PR DESCRIPTION
Solves https://github.com/ros2/rmw_dps/issues/16
The following issues were fixed:

* Turned off CMake linting (opened https://github.com/ament/ament_lint/issues/143)
* Line too long
* C-style casting
* Uncrustify spacing issues

**The CI should now pass and be enforced for subsequent PRs.**