### PR TITLE
Replace apt with rosdep in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - docker exec osrf_ros2_nightly /bin/bash -c "git config --global user.name nobody"
     - docker exec osrf_ros2_nightly /bin/bash -c "git config --global user.email noreply@osrfoundation.org"
 script:
-    - docker exec osrf_ros2_nightly /bin/bash -c "rosdep update && rosdep install --from-paths /shared --ignore-src -r -y"
+    - docker exec osrf_ros2_nightly /bin/bash -c "apt-get update && source /opt/ros/dashing/setup.bash && rosdep update && rosdep install --from-paths /shared --ignore-src -r -y"
     - docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/ && colcon build --packages-up-to rmw_dps_cpp"
-    - docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/ && colcon test --packages-select rmw_dps_cpp"
+    - docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/ && colcon test"
     - docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/ && colcon test-result --verbose"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - docker exec osrf_ros2_nightly /bin/bash -c "git config --global user.name nobody"
     - docker exec osrf_ros2_nightly /bin/bash -c "git config --global user.email noreply@osrfoundation.org"
 script:
-    - docker exec osrf_ros2_nightly /bin/bash -c "apt-get update && apt-get install -y scons python-dev"
+    - docker exec osrf_ros2_nightly /bin/bash -c "rosdep update && rosdep install --from-paths /shared --ignore-src -r -y"
     - docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/ && colcon build --packages-up-to rmw_dps_cpp"
     - docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/ && colcon test --packages-select rmw_dps_cpp"
     - docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/ && colcon test-result --verbose"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ Implementation of the ROS Middleware (rmw) Interface using Intel's [Distributed 
 DPS is a new protocol that implements the publish/subscribe (pub/sub) communication pattern.  For more information see the project's [documentation](https://intel.github.io/dps-for-iot/).
 
 ## Building
-This project adds two build targets: `dps_for_iot_cmake_module` and `rmw_dps_cpp`.  `dps_for_iot_cmake_module` builds the DPS libraries, and requires the `SCons` and `python-config` tools.
-```
-sudo apt install scons python-dev
-```
+This project adds two build targets: `dps_for_iot_cmake_module` and `rmw_dps_cpp`.  `dps_for_iot_cmake_module` builds the DPS libraries, and requires the `SCons` and `python-config` tools (make sure to run `rosdep install` as usual).
+
 `rmw_dps_cpp` is the rmw implementation.  To build, either add rmw_dps to to your local ros2.repos or explicitly clone it.
 
 For the first option, add the following block to ros2.repos and follow the ROS 2 [instructions](https://github.com/ros2/ros2/wiki/Maintaining-a-Source-Checkout) for updating and building.


### PR DESCRIPTION
Part of https://github.com/ros2/rmw_dps/issues/18
Related to (and blocked by) https://github.com/ros2/rmw_dps/pull/23 and https://github.com/ros2/rmw_dps/pull/21

Also updated the instructions since the standard `rosdep` workflow should now be sufficient.

For some reason this doesn't work just yet: 
```
E: Unable to locate package scons
ERROR: the following rosdeps failed to install
  apt: command [apt-get install -y scons] failed
  apt: Failed to detect successful installation of [scons]
```
https://travis-ci.org/AAlon/rmw_dps/builds/535093773
@raghaprasad any ideas what might be wrong?

By the way, with `industrial_ci` it succeeds: https://travis-ci.org/AAlon/rmw_dps/builds/535096134 
