### PR TITLE
Move build & test commands out of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,5 @@ notifications:
       - ros-dps-interest@amazon.com
 services:
     - docker
-before_install:
-    - docker pull osrf/ros2:nightly 
-    - docker run -dit -v "${TRAVIS_BUILD_DIR}:/shared"  --network host --name=osrf_ros2_nightly --privileged osrf/ros2:nightly /bin/bash
-    - docker exec osrf_ros2_nightly /bin/bash -c "git config --global user.name nobody"
-    - docker exec osrf_ros2_nightly /bin/bash -c "git config --global user.email noreply@osrfoundation.org"
 script:
-    - docker exec osrf_ros2_nightly /bin/bash -c "apt-get update && source /opt/ros/dashing/setup.bash && rosdep update && rosdep install --from-paths /shared --ignore-src -r -y"
-    - docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/ && colcon build --packages-up-to rmw_dps_cpp"
-    - docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/ && colcon test"
-    - docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/ && colcon test-result --verbose"
+    - ./travis_build.sh

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+docker pull osrf/ros2:nightly
+docker run -dit -v "${TRAVIS_BUILD_DIR}/..:/shared"  --network host --name=osrf_ros2_nightly --privileged osrf/ros2:nightly /bin/bash
+docker exec osrf_ros2_nightly /bin/bash -c "git config --global user.name nobody"
+docker exec osrf_ros2_nightly /bin/bash -c "git config --global user.email noreply@osrfoundation.org"
+
+docker exec osrf_ros2_nightly /bin/bash -c "apt-get update && source /opt/ros/dashing/setup.bash && rosdep update && rosdep install --from-paths /shared/rmw_dps --ignore-src -r -y"
+docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/rmw_dps && colcon build --packages-up-to rmw_dps_cpp"
+docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/rmw_dps && colcon test"
+docker exec osrf_ros2_nightly /bin/bash -c "source /opt/ros/dashing/setup.bash && cd /shared/rmw_dps && colcon test-result --verbose"


### PR DESCRIPTION
Will be easier to perform upstream builds for changes in dps-for-iot (as suggested at https://github.com/intel/dps-for-iot/pull/99) if we extract those commands to a separate script.