### PR TITLE
Add python-dev dependency to make sure python-config exists

### DIFF
--- a/dps_for_iot_cmake_module/package.xml
+++ b/dps_for_iot_cmake_module/package.xml
@@ -10,7 +10,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>scons</buildtool_depend>
-
+  <buildtool_depend>python-dev</buildtool_depend>
+  
   <build_depend>git</build_depend>
   
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Blocked on https://github.com/ros/rosdistro/pull/21334