### PR TITLE
Pass MinSizeRel build type to DPS library.

### DIFF
--- a/dps_for_iot_cmake_module/CMakeLists.txt
+++ b/dps_for_iot_cmake_module/CMakeLists.txt
@@ -36,6 +36,8 @@ ament_package(
 include(ExternalProject)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(VARIANT "debug")
+elseif(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+  set(VARIANT "min-size-release")
 else()
   set(VARIANT "release")
 endif()


### PR DESCRIPTION
This fixes issue #28 

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>