### PR TITLE
Reduce memory usage of publish

### DIFF
--- a/rmw_dps_cpp/CMakeLists.txt
+++ b/rmw_dps_cpp/CMakeLists.txt
@@ -44,6 +44,7 @@ include_directories(
 add_library(rmw_dps_cpp
   src/client_service_common.cpp
   src/identifier.cpp
+  src/publish_common.cpp
   src/rmw_client.cpp
   src/rmw_compare_gids_equal.cpp
   src/rmw_count.cpp

--- a/rmw_dps_cpp/include/rmw_dps_cpp/custom_client_info.hpp
+++ b/rmw_dps_cpp/include/rmw_dps_cpp/custom_client_info.hpp
@@ -16,6 +16,7 @@
 #define RMW_DPS_CPP__CUSTOM_CLIENT_INFO_HPP_
 
 #include <dps/dps.h>
+#include <dps/event.h>
 
 #include "rmw/rmw.h"
 
@@ -25,6 +26,7 @@ typedef struct CustomClientInfo
 {
   void * request_type_support_;
   void * response_type_support_;
+  DPS_Event * event_;
   DPS_Publication * request_publication_;
   Listener * response_listener_;
   DPS_Node * node_;

--- a/rmw_dps_cpp/src/publish_common.cpp
+++ b/rmw_dps_cpp/src/publish_common.cpp
@@ -1,0 +1,40 @@
+// Copyright 2019 Intel Corporation All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "publish_common.hpp"
+
+void
+_published(
+  DPS_Publication * pub,
+  const DPS_Buffer * bufs,
+  size_t numBufs,
+  DPS_Status status,
+  void * data)
+{
+  (void)pub;
+  (void)bufs;
+  (void)numBufs;
+  DPS_SignalEvent(reinterpret_cast<DPS_Event *>(data), status);
+}
+
+DPS_Status
+publish(DPS_Publication * pub, const uint8_t * data, size_t size, DPS_Event * event)
+{
+  DPS_Buffer buf = {const_cast<uint8_t *>(data), size};
+  DPS_Status ret = DPS_PublishBufs(pub, &buf, 1, 0, _published, event);
+  if (ret == DPS_OK) {
+    ret = DPS_WaitForEvent(event);
+  }
+  return ret;
+}

--- a/rmw_dps_cpp/src/publish_common.hpp
+++ b/rmw_dps_cpp/src/publish_common.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Intel Corporation All rights reserved.
+// Copyright 2019 Intel Corporation All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,23 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_DPS_CPP__CUSTOM_PUBLISHER_INFO_HPP_
-#define RMW_DPS_CPP__CUSTOM_PUBLISHER_INFO_HPP_
+#ifndef PUBLISH_COMMON_HPP_
+#define PUBLISH_COMMON_HPP_
 
 #include <dps/dps.h>
 #include <dps/event.h>
 
-#include <mutex>
-#include <queue>
+DPS_Status
+publish(DPS_Publication * pub, const uint8_t * data, size_t size, DPS_Event * event);
 
-#include "rmw/rmw.h"
-
-typedef struct CustomPublisherInfo
-{
-  DPS_Event * event_;
-  DPS_Publication * publication_;
-  void * type_support_;
-  const char * typesupport_identifier_;
-} CustomPublisherInfo;
-
-#endif  // RMW_DPS_CPP__CUSTOM_PUBLISHER_INFO_HPP_
+#endif  // PUBLISH_COMMON_HPP_

--- a/rmw_dps_cpp/src/rmw_client.cpp
+++ b/rmw_dps_cpp/src/rmw_client.cpp
@@ -119,6 +119,11 @@ rmw_create_client(
     _register_type(impl->node_, info->response_type_support_, info->typesupport_identifier_);
   }
 
+  info->event_ = DPS_CreateEvent();
+  if (!info->event_) {
+    RMW_SET_ERROR_MSG("failed to create event");
+    goto fail;
+  }
   info->request_publication_ = DPS_CreatePublication(impl->node_);
   if (!info->request_publication_) {
     RMW_SET_ERROR_MSG("failed to create publication");
@@ -171,6 +176,9 @@ fail:
   // TODO(malsbat): _delete_typesupport ?
   if (info->request_publication_) {
     DPS_DestroyPublication(info->request_publication_);
+  }
+  if (info->event_) {
+    DPS_DestroyEvent(info->event_);
   }
   delete info->response_listener_;
   delete info;
@@ -225,6 +233,9 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
     // TODO(malsbat): _delete_typesupport ?
     if (info->request_publication_) {
       DPS_DestroyPublication(info->request_publication_);
+    }
+    if (info->event_) {
+      DPS_DestroyEvent(info->event_);
     }
   }
   delete info;

--- a/rmw_dps_cpp/src/rmw_publish.cpp
+++ b/rmw_dps_cpp/src/rmw_publish.cpp
@@ -90,7 +90,7 @@ rmw_publish_serialized_message(
   DPS_Status ret = DPS_Publish(
     info->publication_, reinterpret_cast<uint8_t *>(serialized_message->buffer),
     serialized_message->buffer_length, 0);
-  if (ret == DPS_OK) {
+  if (ret != DPS_OK) {
     RMW_SET_ERROR_MSG("cannot publish data");
     return RMW_RET_ERROR;
   }

--- a/rmw_dps_cpp/src/rmw_publish.cpp
+++ b/rmw_dps_cpp/src/rmw_publish.cpp
@@ -22,6 +22,7 @@
 #include "rmw_dps_cpp/CborStream.hpp"
 #include "rmw_dps_cpp/custom_publisher_info.hpp"
 #include "rmw_dps_cpp/identifier.hpp"
+#include "publish_common.hpp"
 #include "ros_message_serialization.hpp"
 
 extern "C"
@@ -56,7 +57,7 @@ rmw_publish(
   if (_serialize_ros_message(ros_message, ser, info->type_support_,
     info->typesupport_identifier_))
   {
-    DPS_Status ret = DPS_Publish(info->publication_, ser.data(), ser.size(), 0);
+    DPS_Status ret = publish(info->publication_, ser.data(), ser.size(), info->event_);
     if (ret == DPS_OK) {
       returnedValue = RMW_RET_OK;
     }
@@ -87,9 +88,8 @@ rmw_publish_serialized_message(
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     info, "publisher info pointer is null", return RMW_RET_ERROR);
 
-  DPS_Status ret = DPS_Publish(
-    info->publication_, reinterpret_cast<uint8_t *>(serialized_message->buffer),
-    serialized_message->buffer_length, 0);
+  DPS_Status ret = publish(info->publication_, serialized_message->buffer,
+      serialized_message->buffer_length, info->event_);
   if (ret != DPS_OK) {
     RMW_SET_ERROR_MSG("cannot publish data");
     return RMW_RET_ERROR;

--- a/rmw_dps_cpp/src/rmw_publisher.cpp
+++ b/rmw_dps_cpp/src/rmw_publisher.cpp
@@ -167,6 +167,11 @@ rmw_create_publisher(
     _register_type(impl->node_, info->type_support_, info->typesupport_identifier_);
   }
 
+  info->event_ = DPS_CreateEvent();
+  if (!info->event_) {
+    RMW_SET_ERROR_MSG("failed to create event");
+    goto fail;
+  }
   info->publication_ = DPS_CreatePublication(impl->node_);
   if (!info->publication_) {
     RMW_SET_ERROR_MSG("failed to create publication");
@@ -210,6 +215,9 @@ fail:
   _delete_typesupport(info->type_support_, info->typesupport_identifier_);
   if (info->publication_) {
     DPS_DestroyPublication(info->publication_);
+  }
+  if (info->event_) {
+    DPS_DestroyEvent(info->event_);
   }
   delete info;
 
@@ -271,6 +279,9 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
   if (info) {
     if (info->publication_) {
       DPS_DestroyPublication(info->publication_);
+    }
+    if (info->event_) {
+      DPS_DestroyEvent(info->event_);
     }
     if (info->type_support_) {
       auto impl = static_cast<CustomNodeInfo *>(node->data);

--- a/rmw_dps_cpp/src/rmw_request.cpp
+++ b/rmw_dps_cpp/src/rmw_request.cpp
@@ -24,6 +24,7 @@
 #include "rmw_dps_cpp/custom_client_info.hpp"
 #include "rmw_dps_cpp/custom_service_info.hpp"
 #include "rmw_dps_cpp/identifier.hpp"
+#include "publish_common.hpp"
 #include "ros_message_serialization.hpp"
 
 extern "C"
@@ -58,7 +59,7 @@ rmw_send_request(
   if (_serialize_ros_message(ros_request, ser, info->request_type_support_,
     info->typesupport_identifier_))
   {
-    DPS_Status ret = DPS_Publish(info->request_publication_, ser.data(), ser.size(), 0);
+    DPS_Status ret = publish(info->request_publication_, ser.data(), ser.size(), info->event_);
     if (ret == DPS_OK) {
       *sequence_id = DPS_PublicationGetSequenceNum(info->request_publication_);
       returnedValue = RMW_RET_OK;


### PR DESCRIPTION
This PR does two things:
1. Avoid copying the message payload unnecessarily.
2. Block the caller of rmw_publish() and friends until the message has been delivered to the network.  This slows down rapid publishers to prevent unbounded growth of queued publish requests.