### PR TITLE
Fix discovery failure caused by incorrect use of std::map::insert().

### DIFF
--- a/rmw_dps_cpp/include/rmw_dps_cpp/custom_node_info.hpp
+++ b/rmw_dps_cpp/include/rmw_dps_cpp/custom_node_info.hpp
@@ -167,7 +167,7 @@ public:
         } else if (it->second == node) {
           trigger = false;
         } else {
-          discovered_nodes_.insert(it, std::make_pair(uuid, node));
+          it->second = node;
           trigger = true;
         }
       } else {


### PR DESCRIPTION
Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>