### PR TITLE
Fix unicast connection setup via discovery

### DIFF
--- a/rmw_dps_cpp/src/rmw_client.cpp
+++ b/rmw_dps_cpp/src/rmw_client.cpp
@@ -132,7 +132,7 @@ rmw_create_client(
       DPS_ErrTxt(status));
     goto fail;
   }
-  status = DPS_InitPublication(info->request_publication_, &topic, 1, DPS_FALSE,
+  status = DPS_InitPublication(info->request_publication_, &topic, 1, DPS_TRUE,
       Listener::onAcknowledgement);
   if (status != DPS_OK) {
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("failed to initialize publication - %s",

--- a/rmw_dps_cpp/src/rmw_publisher.cpp
+++ b/rmw_dps_cpp/src/rmw_publisher.cpp
@@ -143,7 +143,7 @@ rmw_create_publisher(
     RMW_SET_ERROR_MSG("failed to create publication");
     goto fail;
   }
-  ret = DPS_InitPublication(info->publication_, &topic, 1, DPS_FALSE, nullptr);
+  ret = DPS_InitPublication(info->publication_, &topic, 1, DPS_TRUE, nullptr);
   if (ret != DPS_OK) {
     RMW_SET_ERROR_MSG("failed to initialize publication");
     goto fail;


### PR DESCRIPTION
Fixes ticket #43

Currently the setup of unicast connections via discovery
does not work with dps middleware in ROS2.

The issue is as follows: When a subscriber comes online it sends out a
multicast discovery message. All the subscriber topics (bloom filter
outputs) are merged in a union and sent out as an "interest" message.

When the multicast message is received by the publishing node, it checks
whether any topic is in the set of the received interest. If a match is
found a unicast connection is created and the published message is sent
to the subscriber.

However at the moment, the publisher's bloom filter output takes into
account wildcards whereas they are not considered in the subscriber.
Thus the  publishers bloom filter output will not be in the set of the
subscriber's interests.  Hence, the unicast connection is not created.

This commit sets the noWildCard option on the publishing nodes which
fixes the above problem.

Signed-off-by: Andriy Gelman <andriy.gelman@gmail.com>